### PR TITLE
Remove duplicate networkx requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         'setuptools',
         'dataclasses',
         'pycg',
-        'networkx'
     ]
     )
 


### PR DESCRIPTION
`'networkx'` is present twice in `setup.py`, this Pr fixes that. 