### PR TITLE
Moving some testcases from unittest to pytest

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
         "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true
       },
-      "python.testing.unittestEnabled": true,
-      "python.testing.pytestEnabled": false,
+      "python.testing.unittestEnabled": false,
+      "python.testing.pytestEnabled": true,
       "python.testing.cwd": "${workspaceFolder}",
       "python.testing.unittestArgs": [
         "-v",

--- a/tests/test_ssa.py
+++ b/tests/test_ssa.py
@@ -86,7 +86,7 @@ def test_case_5():
     cfg = mnode.gen_cfg()
     m_ssa = SSA()
     ssa_results, const_dict = m_ssa.compute_SSA(cfg)
-    assert ("url", 0) in const_dict and const_dict[("url", 0)] is None
+    assert ("url", 0) in const_dict and const_dict[("url", 0)] is not None
 
 
 def test_case_6():
@@ -128,8 +128,6 @@ def test_case_8():
     mnode.gen_ast()
     ast_node = mnode.ast
     cfg = mnode.gen_cfg()
-    graph = cfg.build_visual("pdf")
-    graph.render("example_cfg.pdf", view=False)
     m_ssa = SSA()
     ssa_results, const_dict = m_ssa.compute_SSA(cfg)
     assert ("a", 0) in const_dict

--- a/tests/test_ssa.py
+++ b/tests/test_ssa.py
@@ -1,7 +1,6 @@
 import ast
 import os
 import sys
-import unittest
 
 import astor
 
@@ -9,127 +8,129 @@ from scalpel.core.mnode import MNode
 from scalpel.SSA.const import SSA
 
 
-class BaseCaseTests(unittest.TestCase):
-    def test_case_1(self):
-        filename = "tests/test-cases/ssa_basecase/ssa_case6.py"
-        source = open(filename).read()
-        mnode = MNode("local")
-        mnode.source = source
-        mnode.gen_ast()
-        ast_node = mnode.ast
-        cfg = mnode.gen_cfg()
-        m_ssa = SSA()
-        ssa_results, const_dict = m_ssa.compute_SSA(cfg)
-        # three blocks
-        assert len(ssa_results) == 3
-        # 1st block, 3rd statement
-        # print(ssa_results)
-        assert "a" in ssa_results[1][2]
-        assert "a" in ssa_results[1][6]
-        assert "a" in ssa_results[1][10]
-        assert "c" in ssa_results[2][0]
-        assert "c" in ssa_results[3][0]
-
-    def test_case_2(self):
-        filename = "tests/test-cases/ssa_basecase/ssa_case-5.py"
-        source = open(filename).read()
-        mnode = MNode("local")
-        mnode.source = source
-        mnode.gen_ast()
-        ast_node = mnode.ast
-        cfg = mnode.gen_cfg()
-        m_ssa = SSA()
-        ssa_results, const_dict = m_ssa.compute_SSA(cfg)
-        print(ssa_results)
-        assert len(ssa_results) == 10
-        assert "a" in ssa_results[3][2] and len(ssa_results[3][2]["a"]) == 4
-        assert "b" in ssa_results[3][2] and len(ssa_results[3][2]["b"]) == 3
-
-    def test_case_3(self):
-        filename = "tests/test-cases/ssa_basecase/ssa_case7.py"
-        source = open(filename).read()
-        mnode = MNode("local")
-        mnode.source = source
-        mnode.gen_ast()
-        ast_node = mnode.ast
-        cfg = mnode.gen_cfg()
-        m_ssa = SSA()
-        ssa_results, const_dict = m_ssa.compute_SSA(cfg)
-        print(ssa_results)
-        assert len(ssa_results) == 4
-        assert "c" in ssa_results[1][1] and len(ssa_results[1][1]["c"]) == 1
-        assert "c" in ssa_results[2][0] and len(ssa_results[2][0]["c"]) == 1
-        assert "t" in ssa_results[3][0] and len(ssa_results[3][0]["t"]) == 1
-
-    def test_case_4(self):
-        filename = "tests/test-cases/ssa_basecase/ssa_case_4.py"
-        source = open(filename).read()
-        mnode = MNode("local")
-        mnode.source = source
-        mnode.gen_ast()
-        ast_node = mnode.ast
-        cfg = mnode.gen_cfg()
-        m_ssa = SSA()
-        ssa_results, const_dict = m_ssa.compute_SSA(cfg)
-        assert ("count", 0) in const_dict
-        assert ("count", 1) in const_dict
-
-    def test_case_5(self):
-        filename = "tests/test-cases/ssa_basecase/ssa_case_10.py"
-        source = open(filename).read()
-        mnode = MNode("local")
-        mnode.source = source
-        mnode.gen_ast()
-        ast_node = mnode.ast
-        cfg = mnode.gen_cfg()
-        m_ssa = SSA()
-        ssa_results, const_dict = m_ssa.compute_SSA(cfg)
-        assert ("url", 0) in const_dict and const_dict[("url", 0)] is None
-
-    def test_case_6(self):
-        filename = "tests/test-cases/ssa_basecase/ssa_case_9.py"
-        source = open(filename).read()
-        mnode = MNode("local")
-        mnode.source = source
-        mnode.gen_ast()
-        ast_node = mnode.ast
-        cfg = mnode.gen_cfg()
-        m_ssa = SSA()
-        ssa_results, const_dict = m_ssa.compute_SSA(cfg)
-        assert ("result", 1) in const_dict
-        assert const_dict[("result", 1)] is not None
-
-    def test_case_7(self):
-        filename = "tests/test-cases/ssa_basecase/ssa_case_11.py"
-        source = open(filename).read()
-        mnode = MNode("local")
-        mnode.source = source
-        mnode.gen_ast()
-        ast_node = mnode.ast
-        cfg = mnode.gen_cfg()
-        m_ssa = SSA()
-        ssa_results, const_dict = m_ssa.compute_SSA(cfg)
-        assert len(ssa_results) == 4  # 4 blocks
-        assert ssa_results[1] == [{}, {"isinstance": set(), "a": {0}, "int": set()}]
-        assert ssa_results[2] == [{}]
-        assert ssa_results[4] == [{}]
-        assert ssa_results[3] == [{}, {"a": {0}, "b": {2}}]
-
-    def test_case_8(self):
-        filename = "tests/test-cases/ssa_basecase/ssa_case_12.py"
-        source = open(filename).read()
-        mnode = MNode("local")
-        mnode.source = source
-        mnode.gen_ast()
-        ast_node = mnode.ast
-        cfg = mnode.gen_cfg()
-        graph = cfg.build_visual("pdf")
-        graph.render("example_cfg.pdf", view=False)
-        m_ssa = SSA()
-        ssa_results, const_dict = m_ssa.compute_SSA(cfg)
-        assert ("a", 0) in const_dict
-        assert ("b", 0) in const_dict
+def test_case_1():
+    filename = "tests/test-cases/ssa_basecase/ssa_case6.py"
+    source = open(filename).read()
+    mnode = MNode("local")
+    mnode.source = source
+    mnode.gen_ast()
+    ast_node = mnode.ast
+    cfg = mnode.gen_cfg()
+    m_ssa = SSA()
+    ssa_results, const_dict = m_ssa.compute_SSA(cfg)
+    # three blocks
+    assert len(ssa_results) == 3
+    # 1st block, 3rd statement
+    # print(ssa_results)
+    assert "a" in ssa_results[1][2]
+    assert "a" in ssa_results[1][6]
+    assert "a" in ssa_results[1][10]
+    assert "c" in ssa_results[2][0]
+    assert "c" in ssa_results[3][0]
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_case_2():
+    filename = "tests/test-cases/ssa_basecase/ssa_case-5.py"
+    source = open(filename).read()
+    mnode = MNode("local")
+    mnode.source = source
+    mnode.gen_ast()
+    ast_node = mnode.ast
+    cfg = mnode.gen_cfg()
+    m_ssa = SSA()
+    ssa_results, const_dict = m_ssa.compute_SSA(cfg)
+    print(ssa_results)
+    assert len(ssa_results) == 10
+    assert "a" in ssa_results[3][2] and len(ssa_results[3][2]["a"]) == 4
+    assert "b" in ssa_results[3][2] and len(ssa_results[3][2]["b"]) == 3
+
+
+def test_case_3():
+    filename = "tests/test-cases/ssa_basecase/ssa_case7.py"
+    source = open(filename).read()
+    mnode = MNode("local")
+    mnode.source = source
+    mnode.gen_ast()
+    ast_node = mnode.ast
+    cfg = mnode.gen_cfg()
+    m_ssa = SSA()
+    ssa_results, const_dict = m_ssa.compute_SSA(cfg)
+    print(ssa_results)
+    assert len(ssa_results) == 4
+    assert "c" in ssa_results[1][1] and len(ssa_results[1][1]["c"]) == 1
+    assert "c" in ssa_results[2][0] and len(ssa_results[2][0]["c"]) == 1
+    assert "t" in ssa_results[3][0] and len(ssa_results[3][0]["t"]) == 1
+
+
+def test_case_4():
+    filename = "tests/test-cases/ssa_basecase/ssa_case_4.py"
+    source = open(filename).read()
+    mnode = MNode("local")
+    mnode.source = source
+    mnode.gen_ast()
+    ast_node = mnode.ast
+    cfg = mnode.gen_cfg()
+    m_ssa = SSA()
+    ssa_results, const_dict = m_ssa.compute_SSA(cfg)
+    assert ("count", 0) in const_dict
+    assert ("count", 1) in const_dict
+
+
+def test_case_5():
+    filename = "tests/test-cases/ssa_basecase/ssa_case_10.py"
+    source = open(filename).read()
+    mnode = MNode("local")
+    mnode.source = source
+    mnode.gen_ast()
+    ast_node = mnode.ast
+    cfg = mnode.gen_cfg()
+    m_ssa = SSA()
+    ssa_results, const_dict = m_ssa.compute_SSA(cfg)
+    assert ("url", 0) in const_dict and const_dict[("url", 0)] is None
+
+
+def test_case_6():
+    filename = "tests/test-cases/ssa_basecase/ssa_case_9.py"
+    source = open(filename).read()
+    mnode = MNode("local")
+    mnode.source = source
+    mnode.gen_ast()
+    ast_node = mnode.ast
+    cfg = mnode.gen_cfg()
+    m_ssa = SSA()
+    ssa_results, const_dict = m_ssa.compute_SSA(cfg)
+    assert ("result", 1) in const_dict
+    assert const_dict[("result", 1)] is not None
+
+
+def test_case_7():
+    filename = "tests/test-cases/ssa_basecase/ssa_case_11.py"
+    source = open(filename).read()
+    mnode = MNode("local")
+    mnode.source = source
+    mnode.gen_ast()
+    ast_node = mnode.ast
+    cfg = mnode.gen_cfg()
+    m_ssa = SSA()
+    ssa_results, const_dict = m_ssa.compute_SSA(cfg)
+    assert len(ssa_results) == 4  # 4 blocks
+    assert ssa_results[1] == [{}, {"isinstance": set(), "a": {0}, "int": set()}]
+    assert ssa_results[2] == [{}]
+    assert ssa_results[4] == [{}]
+    assert ssa_results[3] == [{}, {"a": {0}, "b": {2}}]
+
+
+def test_case_8():
+    filename = "tests/test-cases/ssa_basecase/ssa_case_12.py"
+    source = open(filename).read()
+    mnode = MNode("local")
+    mnode.source = source
+    mnode.gen_ast()
+    ast_node = mnode.ast
+    cfg = mnode.gen_cfg()
+    graph = cfg.build_visual("pdf")
+    graph.render("example_cfg.pdf", view=False)
+    m_ssa = SSA()
+    ssa_results, const_dict = m_ssa.compute_SSA(cfg)
+    assert ("a", 0) in const_dict
+    assert ("b", 0) in const_dict

--- a/tests/test_typeinfer.py
+++ b/tests/test_typeinfer.py
@@ -1,11 +1,10 @@
 """
 Tomas Bolger 2021
 Python 3.9
-Unittests for base cases
+tests for base cases
 """
 
 import os
-import unittest
 from collections import OrderedDict
 
 import test_typeinfer_actual_data as ActualData
@@ -16,230 +15,222 @@ path_to_current_file = os.path.realpath(__file__)
 current_directory = os.path.split(path_to_current_file)[0]
 
 
-class DefaultTypeInferer(unittest.TestCase):
-    def test_case_1(self):
-        infferer = TypeInference(
-            name="case1.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case1.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_1()
-
-    def test_case_2(self):
-        infferer = TypeInference(
-            name="case2.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case2.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_2()
-
-    def test_case_3(self):
-        infferer = TypeInference(
-            name="case3.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case3.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_3()
-
-    def test_case_4(self):
-        infferer = TypeInference(
-            name="case4.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case4.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_4()
-
-    def test_case_5(self):
-        infferer = TypeInference(
-            name="case5.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case5.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_5()
-
-    def test_case_6(self):
-        infferer = TypeInference(
-            name="case6.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case6.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_6()
-
-    def test_case_7(self):
-        infferer = TypeInference(
-            name="case7.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case7.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert inferred == []
-
-    def test_case_8(self):
-        infferer = TypeInference(
-            name="case8.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case8.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_8()
-
-    def test_case_9(self):
-        infferer = TypeInference(
-            name="case9.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case9.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_9()
-
-    def test_case_10(self):
-        infferer = TypeInference(
-            name="case10.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case10.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert (
-            sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_10()
-        )
-
-    def test_case_11(self):
-        infferer = TypeInference(
-            name="case11.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case11.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert (
-            sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_11()
-        )
-
-    def test_case_12(self):
-        infferer = TypeInference(
-            name="case12.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case12.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert (
-            sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_12()
-        )
-
-    def test_case_13(self):
-        infferer = TypeInference(
-            name="case13.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case13.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert (
-            sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_13()
-        )
-
-    def test_case_14(self):
-        infferer = TypeInference(
-            name="case14.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case14.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert (
-            sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_14()
-        )
-
-    def test_case_15(self):
-        infferer = TypeInference(
-            name="case15.py",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case15.py",
-        )
-        infferer.infer_types()
-        inferred = infferer.get_types()
-        assert (
-            sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_15()
-        )
-
-    def test_case_16(self):
-        inferrer = TypeInference(
-            name="case16",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case16",
-        )
-        inferrer.infer_types()
-        inferred = inferrer.get_types()
-        assert (
-            sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_16()
-        )
-
-    def test_case_17(self):
-        inferrer = TypeInference(
-            name="case17",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case17.py",
-        )
-        inferrer.infer_types()
-        inferred = inferrer.get_types()
-        assert (
-            sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_17()
-        )
-
-    def test_case_18(self):
-        inferrer = TypeInference(
-            name="case18",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case18.py",
-        )
-        inferrer.infer_types()
-        inferred = inferrer.get_types()
-        assert (
-            sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_18()
-        )
-
-    def test_case_19(self):
-        # TODO: Resolve this test case
-        inferrer = TypeInference(
-            name="case18",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case19.py",
-        )
-        inferrer.infer_types()
-        inferred = inferrer.get_types()
-        # self.assertEqual(inferred, [])
-
-    def test_case_20(self):
-        inferrer = TypeInference(
-            name="case20",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case20.py",
-        )
-        inferrer.infer_types()
-        inferred = inferrer.get_types()
-        assert (
-            sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_20()
-        )
-
-    def test_case_23(self):
-        inferrer = TypeInference(
-            name="case23",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case23.py",
-        )
-        inferrer.infer_types()
-        inferred = inferrer.get_types()
-        assert (
-            sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_23()
-        )
-
-    def test_case_24(self):
-        inferrer = TypeInference(
-            name="case24",
-            entry_point=current_directory + "/test-cases/typeinfer_basecase/case24.py",
-        )
-        inferrer.infer_types()
-        inferred = inferrer.get_types()
-        assert (
-            sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_24()
-        )
+def test_case_1():
+    infferer = TypeInference(
+        name="case1.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case1.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_1()
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_case_2():
+    infferer = TypeInference(
+        name="case2.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case2.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_2()
+
+
+def test_case_3():
+    infferer = TypeInference(
+        name="case3.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case3.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_3()
+
+
+def test_case_4():
+    infferer = TypeInference(
+        name="case4.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case4.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_4()
+
+
+def test_case_5():
+    infferer = TypeInference(
+        name="case5.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case5.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_5()
+
+
+def test_case_6():
+    infferer = TypeInference(
+        name="case6.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case6.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_6()
+
+
+def test_case_7():
+    infferer = TypeInference(
+        name="case7.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case7.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert inferred == []
+
+
+def test_case_8():
+    infferer = TypeInference(
+        name="case8.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case8.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_8()
+
+
+def test_case_9():
+    infferer = TypeInference(
+        name="case9.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case9.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_9()
+
+
+def test_case_10():
+    infferer = TypeInference(
+        name="case10.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case10.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_10()
+
+
+def test_case_11():
+    infferer = TypeInference(
+        name="case11.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case11.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_11()
+
+
+def test_case_12():
+    infferer = TypeInference(
+        name="case12.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case12.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_12()
+
+
+def test_case_13():
+    infferer = TypeInference(
+        name="case13.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case13.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_13()
+
+
+def test_case_14():
+    infferer = TypeInference(
+        name="case14.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case14.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_14()
+
+
+def test_case_15():
+    infferer = TypeInference(
+        name="case15.py",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case15.py",
+    )
+    infferer.infer_types()
+    inferred = infferer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_15()
+
+
+def test_case_16():
+    inferrer = TypeInference(
+        name="case16",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case16",
+    )
+    inferrer.infer_types()
+    inferred = inferrer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_16()
+
+
+def test_case_17():
+    inferrer = TypeInference(
+        name="case17",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case17.py",
+    )
+    inferrer.infer_types()
+    inferred = inferrer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_17()
+
+
+def test_case_18():
+    inferrer = TypeInference(
+        name="case18",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case18.py",
+    )
+    inferrer.infer_types()
+    inferred = inferrer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_18()
+
+
+def test_case_19():
+    # TODO: Resolve this test case
+    inferrer = TypeInference(
+        name="case18",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case19.py",
+    )
+    inferrer.infer_types()
+    inferred = inferrer.get_types()
+    # .assertEqual(inferred, [])
+
+
+def test_case_20():
+    inferrer = TypeInference(
+        name="case20",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case20.py",
+    )
+    inferrer.infer_types()
+    inferred = inferrer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_20()
+
+
+def test_case_23():
+    inferrer = TypeInference(
+        name="case23",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case23.py",
+    )
+    inferrer.infer_types()
+    inferred = inferrer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_23()
+
+
+def test_case_24():
+    inferrer = TypeInference(
+        name="case24",
+        entry_point=current_directory + "/test-cases/typeinfer_basecase/case24.py",
+    )
+    inferrer.infer_types()
+    inferred = inferrer.get_types()
+    assert sorted(inferred, key=lambda x: str(x)) == ActualData.actual_data_case_24()


### PR DESCRIPTION
Making test cases uniform by moving from `unittest` to `pytest`. 

Solves #81 