### PR TITLE
SSA-Renaming-Fix

### DIFF
--- a/src/scalpel/SSA/const.py
+++ b/src/scalpel/SSA/const.py
@@ -130,6 +130,14 @@ class SSA:
             for i in range(n_stmts):
                 stmt_stored_idents = stored_idents[i]
                 stmt_loaded_idents = loaded_idents[i]
+
+                # same block, number used identifiers
+                for ident in stmt_loaded_idents:
+                    # a list of dictions for each of idents used in this statement
+                    phi_loaded_idents = block_renamed_loaded[block.id][i]
+                    if ident in ident_name_counter:
+                        phi_loaded_idents[ident].add(ident_name_counter[ident])
+
                 stmt_renamed_stored = {}
 
                 for ident in stmt_stored_idents:
@@ -147,13 +155,6 @@ class SSA:
 
                     stmt_renamed_stored[ident] = ident_name_counter[ident]
                 block_renamed_stored[block.id] += [stmt_renamed_stored]
-
-                # same block, number used identifiers
-                for ident in stmt_loaded_idents:
-                    # a list of dictions for each of idents used in this statement
-                    phi_loaded_idents = block_renamed_loaded[block.id][i]
-                    if ident in ident_name_counter:
-                        phi_loaded_idents[ident].add(ident_name_counter[ident])
 
             df_block_ids = DF[block.id]
             for df_block_id in df_block_ids:


### PR DESCRIPTION
I changed up the order of renaming and using the names in loads from SSA to support the following example:

code_str = """
b = 10
b = b + 1
if b>0:
    a = a+b
else:
    a = 10
print(a)
"""

Before b = b + 1 resulted in b_1 = b_1 + 1 instead of b_1 = b_0 + 1