### PR TITLE
add DUC module

### DIFF
--- a/src/scalpel/__init__.py
+++ b/src/scalpel/__init__.py
@@ -7,7 +7,7 @@ everybody and reusable in various contexts.
 For more information, please see Scalpel: [The Python Static Analysis Framework](https://github.com/SMAT-Lab/Scalpel)
 """
 
-__all__ = ["cfg", "call_graph", "SSA", "core", "typeinfer", "import_graph", "rewriter", "file_system"]
+__all__ = ["cfg", "call_graph", "SSA", "core", "typeinfer", "import_graph", "duc", "rewriter", "file_system"]
 __version__ = "1.0dev"
 
 from .util import check_python_version

--- a/src/scalpel/duc.py
+++ b/src/scalpel/duc.py
@@ -1,0 +1,116 @@
+"""
+This module implements a `DUC` class for define-use chain construction.
+"""
+
+import ast
+from dataclasses import dataclass
+import sys
+from typing import Iterable, List, NoReturn, Tuple, Union
+from scalpel.cfg import CFG
+
+
+@dataclass
+class Location:
+    """
+    A location within a source file.
+    """
+
+    line: int
+    """
+    The line (first line is 1).
+    """
+
+    column: int
+    """
+    The column offset (first character in the line is 0).
+    """
+
+
+@dataclass
+class Definition:
+    name: str
+    location: Location
+    ast_node: Union[
+        ast.AnnAssign,
+        ast.Assign,
+        ast.AugAssign,
+        ast.AsyncFor,
+        ast.AsyncFunctionDef,
+        ast.ExceptHandler,
+        ast.FunctionDef,
+        ast.ClassDef,
+        ast.For,
+        # imports
+        ast.alias,
+        ast.arg,
+        ast.comprehension,
+        ast.withitem,
+        # walrus operator
+        (ast.NamedExpr if sys.version_info >= (3, 8) else NoReturn),
+        # match patterns
+        (ast.MatchAs if sys.version_info >= (3, 10) else NoReturn),
+    ]
+
+
+@dataclass
+class Reference:
+    name: str
+    location: Location
+    ast_node: ast.Name
+
+
+class DUC:
+    """
+    Definition-use chain (DUC). This class provides methods to query the
+    definitions and references for a name in a lexical scope.
+    """
+
+    def __init__(self, cfg: CFG):
+        """
+        Constructs a def-use chain.
+        Args:
+            cfg: The control flow graph.
+        """
+        pass
+
+    def get_lexical_scopes(self) -> Iterable[str]:
+        """
+        Iterates the names of all the lexical scopes.
+        Returns: An iterable of the lexical scope names (strings).
+        """
+        pass
+
+    def get_definitions_and_references(
+        self, scope_name: str
+    ) -> Tuple[List[Definition], List[Reference]]:
+        """
+        Retrieves all the definitions and references for a lexical scope.
+        Args:
+            scope_name: The name of the lexical scope (string).
+        Returns:
+            A tuple of `(definitions, references)`. `definitions` is a list of
+            all the definitions (AST nodes) in the lexical scope `scope_name`,
+            and `references` is a list of all the references (AST nodes) in the
+            scope.
+        """
+        pass
+
+    def get_definitions(self, scope_name: str, name: str) -> List[Definition]:
+        """
+        Retrieves the definitions for a variable in a lexical scope.
+        Args:
+            scope_name: The name of the lexical scope (string).
+            name: The name of the variable (string).
+        Returns: A list of definitions (AST nodes).
+        """
+        pass
+
+    def get_references(self, scope_name: str, name: str) -> List[Reference]:
+        """
+        Retrieves the references for a variable in a lexical scope.
+        Args:
+            scope_name: The name of the lexical scope (string).
+            name: The name of the variable (string).
+        Returns: A list of references (AST nodes).
+        """
+        pass

--- a/tests/test_duc.py
+++ b/tests/test_duc.py
@@ -1,0 +1,192 @@
+import ast
+import textwrap
+from typing import List
+from scalpel.cfg import CFGBuilder
+from scalpel.duc import Definition, DUC, Reference
+
+
+def make_duc(name: str, src: str) -> DUC:
+    return DUC(
+        CFGBuilder().build_from_src(
+            name,
+            textwrap.dedent(src),
+        )
+    )
+
+
+def assert_num_defs_refs(duc: DUC, scope: str, num_defs: int, num_refs: int) -> None:
+    defs, refs = duc.get_definitions_and_references(scope)
+    assert len(defs) == num_defs
+    assert len(refs) == num_refs
+
+
+def get_and_check_defs(duc: DUC, scope: str, name: str, num: int) -> List[Definition]:
+    defs = duc.get_definitions(scope, name)
+    assert len(defs) == num, f"expected {num} definitions, got {len(defs)}"
+    assert all(
+        def_.name == name for def_ in defs
+    ), f"not all definitions have name {name}"
+    return defs
+
+
+def get_and_check_def(duc: DUC, scope: str, name: str) -> Definition:
+    return get_and_check_defs(duc, scope, name, 1)[0]
+
+
+def get_and_check_refs(duc: DUC, scope: str, name: str, num: int) -> List[Reference]:
+    refs = duc.get_references(scope, name)
+    assert len(refs) == num, f"expected {num} references, got {len(refs)}"
+    assert all(ref.name == name for ref in refs), f"not all references have name {name}"
+    return refs
+
+
+def test_simple() -> None:
+    duc = make_duc(
+        "simple",
+        """\
+        a = 1
+        print(a + 1)
+        """,
+    )
+
+    scopes = list(duc.get_lexical_scopes())
+    assert len(scopes) == 1
+    global_scope = scopes[0]
+
+    assert_num_defs_refs(duc, global_scope, 1, 1)
+    a_def = get_and_check_def(duc, global_scope, "a")
+    assert isinstance(a_def.ast_node, ast.Assign)
+    get_and_check_refs(duc, global_scope, "a", 1)
+
+
+def test_multiple_scopes() -> None:
+    duc = make_duc(
+        "multiple_scopes",
+        """\
+        a = 1
+        def f():
+            a = 2
+            b = 3
+        """,
+    )
+
+    scopes = list(duc.get_lexical_scopes())
+    assert len(scopes) == 2
+    global_scope, f_scope = scopes
+
+    assert_num_defs_refs(duc, global_scope, 2, 0)
+    a_def = get_and_check_def(duc, global_scope, "a")
+    assert isinstance(a_def.ast_node, ast.Assign)
+    assert a_def.location.line == 1
+    f_def = get_and_check_def(duc, global_scope, "f")
+    assert isinstance(f_def.ast_node, ast.FunctionDef)
+
+    assert_num_defs_refs(duc, f_scope, 2, 0)
+    f_a_def = get_and_check_def(duc, f_scope, "a")
+    assert isinstance(f_a_def.ast_node, ast.Assign)
+    assert f_a_def.location.line == 3
+    f_b_def = get_and_check_def(duc, f_scope, "b")
+    assert isinstance(f_b_def.ast_node, ast.Assign)
+
+
+def test_reassign() -> None:
+    duc = make_duc(
+        "reassign",
+        """\
+        a = 1
+        print(a)
+        a = 2
+        print(a)
+        """,
+    )
+
+    scopes = list(duc.get_lexical_scopes())
+    assert len(scopes) == 1
+    global_scope = scopes[0]
+
+    assert_num_defs_refs(duc, global_scope, 2, 2)
+
+    a_def1, a_def2 = get_and_check_defs(duc, global_scope, "a", 2)
+    assert a_def1.location.line == 1
+    assert a_def2.location.line == 3
+
+    a_ref1, a_ref2 = get_and_check_refs(duc, global_scope, "a", 2)
+    assert a_ref1.location.line == 2
+    assert a_ref2.location.line == 4
+
+
+def test_classes() -> None:
+    duc = make_duc(
+        "classes",
+        """\
+        a = 1
+        class C:
+            a = 2
+            b = a
+            def f(self):
+                print(a)
+                print(b)
+        print(a)
+        """,
+    )
+
+    scopes = list(duc.get_lexical_scopes())
+    assert len(scopes) == 3
+    global_scope, c_scope, c_f_scope = scopes
+
+    assert_num_defs_refs(duc, global_scope, 1, 1)
+    assert get_and_check_def(duc, global_scope, "a").location.line == 1
+    global_a_ref1, global_a_ref2 = get_and_check_refs(duc, global_scope, "a", 2)
+    assert global_a_ref1.location.line == 6  # print(a) inside C.f
+    assert global_a_ref2.location.line == 8  # print(a) in global scope
+
+    assert_num_defs_refs(duc, c_scope, 2, 1)
+    a_def = get_and_check_def(duc, c_scope, "a")
+    assert a_def.location.line == 3
+    a_ref = get_and_check_refs(duc, c_scope, "a", 1)[0]
+    assert a_ref.location.line == 4  # b = a
+
+    assert_num_defs_refs(duc, c_f_scope, 1, 2)
+    self_def = get_and_check_def(duc, c_f_scope, "self")
+    assert isinstance(self_def.ast_node, ast.arg)
+
+
+def test_multiple_defs() -> None:
+    duc = make_duc(
+        "multiple_defs",
+        """\
+        a = 1
+        for a in range(5):
+            pass
+        def f(a, b):
+            print(a, b)
+        """,
+    )
+
+    scopes = list(duc.get_lexical_scopes())
+    assert len(scopes) == 2
+    global_scope, f_scope = scopes[0]
+
+    assert_num_defs_refs(duc, global_scope, 3, 0)
+    global_a_def1, global_a_def2 = get_and_check_defs(duc, global_scope, "a", 2)
+    assert isinstance(global_a_def1.ast_node, ast.Assign)
+    assert isinstance(global_a_def2.ast_node, ast.For)
+    f_def = get_and_check_def(duc, global_scope, "f")
+    assert isinstance(f_def, ast.FunctionDef)
+    get_and_check_refs(duc, global_scope, "a", 0)
+
+    assert_num_defs_refs(duc, f_scope, 2, 2)
+    assert isinstance(get_and_check_def(duc, f_scope, "a").ast_node, ast.arg)
+    assert isinstance(get_and_check_def(duc, f_scope, "b").ast_node, ast.arg)
+
+
+def main() -> None:
+    test_simple()
+    test_multiple_scopes()
+    test_reassign()
+    test_classes()
+    test_multiple_defs()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds an initial empty skeleton `DUC` class for definition-use chains, allowing consumers to
- iterate all lexical scopes
- query all definitions and references in a lexical scope
- query definitions of a name in a scope
- query references of a name in a scope

This PR also adds some unit cases for this class.